### PR TITLE
Run common startup to improve startup times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ WORKDIR /galaxy/server/
 RUN make client-production \
       && rm /galaxy/server/client/node_modules -rf
 
+# Run common startup to prefetch wheels
+RUN ./scripts/common_startup.sh
+
 # Start new build stage for final image
 FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive 
@@ -45,3 +48,5 @@ COPY --chown=galaxy:galaxy --from=builder /galaxy/server .
 
 EXPOSE 8080
 USER galaxy
+
+CMD sh run.sh --skip-wheels --skip-client-build --skip-tool-dependency-initialization

--- a/group_vars/all
+++ b/group_vars/all
@@ -1,9 +1,7 @@
-## galaxy-os role variables
-install_slurm_drmaa_lib: no
-
 ## galaxy role variables
 galaxy_manage_clone: false 
 galaxy_manage_download: true 
+pip_extra_args: "--no-cache-dir --compile"
 
 # Cannot use 19.01 unless we make an archive. 
 # Must override this variable because constructed value is incorrect for download.

--- a/playbook_localhost.yml
+++ b/playbook_localhost.yml
@@ -17,8 +17,15 @@
   roles:
   - galaxy
 
+# Client dependencies need to be installed before running this, so uncomment
+# once they are moved here
+#   post_tasks:
+#   - name: Run common startup to prefetch wheels
+#     shell: "{{ galaxy_server_dir }}/scripts/common_startup.sh"
+#     args:
+#         chdir: "{{ galaxy_server_dir }}"
+
   # No need if using multi-stage build
-  #post_tasks:
   #  - name: Clean up
   #    apt:
   #      autoclean: yes


### PR DESCRIPTION
This reduces startup time to ~10s from ~15s on subsequent runs but for the initial run, the database migration step always dominates, taking ~60+ seconds.

The only parameter that seems to have any measurable impact is --skip-wheels, since the other two are already done/finish quick anyway.

The prefetch task is in the Dockerfile till it can be moved to ansible pending: https://github.com/galaxyproject/ansible-galaxy/pull/52