### PR TITLE
Strip python source code to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ WORKDIR /galaxy/server/
 RUN make client-production \
       && rm /galaxy/server/client/node_modules -rf
 
+# Strip all source code
+RUN find .venv/lib/python2.7/site-packages/ -name "*.py" -exec rm -f {} \;
+
 # Start new build stage for final image
 FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive 


### PR DESCRIPTION
Stripping python source from the site-packages folder saves ~125MB. I don't know whether there's a a better way to do this, but for wheels, there doesn't seem to be an option for installing compiled code only. Maybe @natefoo knows? ~~The other potential ill-effect of losing the source is that shell executable python scripts must now be executed through the python interpreter, not directly through bash, but this is probably not an issue?~~ Executable python scripts seem to be a non-issue, since they reside in .venv/bin, not in .venv/site-packages.