### PR TITLE
Adding curl to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ RUN set -xe; \
         python-virtualenv \
         vim \
         libpython2.7 \
+        curl \
     && apt-get autoremove -y && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 


### PR DESCRIPTION
If someone with access to the docker hub could also push the new image with `curl` when/if this is merged please, that'd be great.

This is needed, at least, for installing conda (either `wget` or `curl`) and installing `involucro`