### PR TITLE
Upgraded to 20.05

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG ROOT_DIR=/galaxy
 ARG SERVER_DIR=$ROOT_DIR/server
 # For much faster build time override this with image0 (Dockerfile.0 build):
 #   docker build --build-arg BASE=<image0 name>...
-ARG BASE=ubuntu:18.04
+ARG BASE=ubuntu:20.04
 # NOTE: the value of GALAXY_USER must be also hardcoded in COPY in final stage
 ARG GALAXY_USER=galaxy
 
@@ -36,7 +36,6 @@ RUN set -xe; \
         gcc \
         libpython3.6 \
         locales locales-all \
-    && apt-add-repository -y ppa:ansible/ansible \
     && apt-get -qq update && apt-get install -y --no-install-recommends \
         ansible \
     && apt-get autoremove -y && apt-get clean \
@@ -68,7 +67,7 @@ RUN rm -rf \
         test-data
 
 # Stage-2
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ROOT_DIR
 ARG SERVER_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ COPY . .
 ENV LC_ALL en_US.UTF-8
 RUN ansible-playbook -i localhost, playbook.yml -vv
 
+RUN /galaxy/server/.venv/bin/pip install psycopg2-binary==2.8.4
+
 # Remove build artifacts + files not needed in container
 WORKDIR $SERVER_DIR
 # Save commit hash of HEAD before zapping git folder

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ COPY . .
 ENV LC_ALL en_US.UTF-8
 RUN ansible-playbook -i localhost, playbook.yml -vv
 
-RUN /galaxy/server/.venv/bin/pip install psycopg2-binary==2.8.4
+RUN cat /galaxy/server/lib/galaxy/dependencies/conditional-requirements.txt | grep psycopg2-binary | xargs /galaxy/server/.venv/bin/pip install
 
 # Remove build artifacts + files not needed in container
 WORKDIR $SERVER_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,13 @@ ARG ROOT_DIR=/galaxy
 ARG SERVER_DIR=$ROOT_DIR/server
 # For much faster build time override this with image0 (Dockerfile.0 build):
 #   docker build --build-arg BASE=<image0 name>...
-ARG BASE=ubuntu:20.04
+ARG STAGE1_BASE=ubuntu:20.04
+ARG STAGE2_BASE=$STAGE1_BASE
 # NOTE: the value of GALAXY_USER must be also hardcoded in COPY in final stage
 ARG GALAXY_USER=galaxy
 
 # Stage-1
-FROM $BASE AS stage1
+FROM $STAGE1_BASE AS stage1
 ARG DEBIAN_FRONTEND=noninteractive
 ARG SERVER_DIR
 
@@ -67,7 +68,7 @@ RUN rm -rf \
         test-data
 
 # Stage-2
-FROM ubuntu:20.04
+FROM $STAGE2_BASE
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ROOT_DIR
 ARG SERVER_DIR

--- a/Dockerfile.0
+++ b/Dockerfile.0
@@ -11,10 +11,12 @@ RUN set -xe; \
         git \
         make \
         python3-virtualenv \
+        python3-dev \
         software-properties-common \
+        ssh \
         gcc \
         libpython3.6 \
-    && apt-add-repository -y ppa:ansible/ansible \
+        locales locales-all \
     && apt-get -qq update && apt-get install -y --no-install-recommends \
         ansible \
     && apt-get autoremove -y && apt-get clean \

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 An Ansible playbook for building a Galaxy Docker image for Kubernetes.
 
-Note that this Galaxy Docker image is not intended to be run standalone but
-instead used as part of a container orchestration system, namely Kubernetes.
+The main purpose of this Docker image is to support Kubernetes, although the
+image can be run standalone - by default with an sqlite database.
 See [Galaxy Helm chart](https://github.com/galaxyproject/galaxy-helm) for how
-to go about doing this.
+to set up on Kubernetes.
 
 ## Setup the environment for building the image
 1. Clone the playbook repo.
@@ -20,25 +20,22 @@ to go about doing this.
     ansible-galaxy install -r requirements_roles.yml -p roles --force-with-deps
     ```
 
-## Build a container image (simple)
+## Build and run container image (simple)
 
-The next section contains instructions for a full container image that is
-testable when deployed alongside a Postgres container and may be useful for
-producing compatible database dumps if needed. However, the Helm chart is fully
-functional when run from an image built with a simple standalone ``docker
-build``. To build this container, run the following command, changing the tag
-as desired.
+To build this container, run the following command, changing the tag
+as desired. You will then be able to access Galaxy on port 8080.
 
 ```
-docker build --no-cache --tag galaxy/galaxy-k8s:20.01 .
+docker build --no-cache --tag galaxy/galaxy-k8s:latest .
+docker run -it --rm -p 8080:8080 galaxy/galaxy-k8s:latest
 ```
 
-## Build a container image (full with Postgres database)
-We will build the container configured to use an external PostgreSQL database
-so we need to run a Postgres container in parallel to the one building the
-Galaxy image.
+## Build and run a container image (full with Postgres database)
+The default build above uses an sqlite database, although the image has the
+necessary postgres drivers installed. In order to start Galaxy with a Postgres
+database, we need to run a Postgres container in parallel.
 
-1. It is necessary to link the Galaxy build container and the Postgres one. For
+1. It is necessary to link the Galaxy container and the Postgres one. For
    this, we need to create a dedicated bridge network so the `docker build`
    command can link to a running Postgres container. This needs to be done only
    once on a machine where you're building the image.
@@ -49,7 +46,7 @@ Galaxy image.
 
 2. Now we create a database that Galaxy will use. We need to provide a path on
    the host machine where the database files will be persisted (e.g.,
-   `~/tmp_local/docker/volumes/pg_gxy20.01`). If you are using a Mac to build
+   `~/tmp_local/docker/volumes/pg_gxylatest`). If you are using a Mac to build
    the image, do not use the `/tmp` directory for this, as it is periodically
    cleaned by the OS, so your data will not be persisted properly. Note that we
    can reuse the same path/database multiple times. The first time we build the
@@ -65,63 +62,27 @@ Galaxy image.
     -v </local/path/to/database/dir>:/var/lib/postgresql/data postgres:11.6
     ```
 
-3. Now we can build the Galaxy image. First update `playbook.yml` to set
+3. Now we can build the Galaxy image against the psql image or skip this step
+   if you have already built the image. First update `playbook.yml` to set
    `galaxy_manage_database` to `true`. If the database username and password
    were changed in the above step, correspondingly update the
    `database_connection` line. In a separate terminal tab, run the following
    command, changing the tag as desired.
 
     ```
-    docker build --no-cache --network gnet --tag galaxy/galaxy-k8s:20.01 .
+    docker build --no-cache --network gnet --tag galaxy/galaxy-k8s:latest .
     ```
 
-   You may stop the Postgres container after the Galaxy image has been built.
+4. To test the build, first ensure that the Postgres container is
+   running (refer to step 2 in the previous section). Then run the following:
 
-## Run the container
-As stated earlier, this container is not intended to be used for running Galaxy
-as is but should be used as part of a Kubernetes deployment. However, to test
-that the build was successful, it is possible to start Galaxy in limited
-capacity. If you are running Docker for Desktop, you will need to add Nginx
-ingress to your Kubernetes: https://kubernetes.github.io/ingress-nginx/deploy/
+    ```
+    docker run -it --rm --network gnet -p 8080:8080 \
+    -e GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION="postgresql://galaxydbuser:42@gpsql/galaxy" \
+    galaxy/galaxy-k8s:latest
+    ```
 
-To test the build, first ensure that the Postgres container is
-running (refer to step 2 in the previous section). Then run the following:
-
-```
-docker run -it --rm --network gnet -p 8080:8080 galaxy/galaxy-k8s:20.01 bash
-```
-
-Before we can start the Galaxy process, we need to create
-`config/uwsgi.yaml` with the following content:
-
-    uwsgi:
-        virtualenv: /galaxy/server/.venv
-        processes: 1
-        http: 0.0.0.0:8080
-        pythonpath: /galaxy/server/lib
-        thunder-lock: true
-        manage-script-name: true
-        buffer-size: 16384
-        offload-threads: 2
-        threads: 4
-        die-on-term: true
-        master: true
-        hook-master-start: unix_signal:2 gracefully_kill_them_all
-        enable-threads: true
-        py-call-osafterfork: true
-        static-map: /static/style=/galaxy/server/static/style/blue
-        static-map: /static=/galaxy/server/static
-        static-map: /favicon.ico=/galaxy/server/static/favicon.ico
-        static-safe: /galaxy/server/client/galaxy/images
-        mount: /=galaxy.webapps.galaxy.buildapp:uwsgi_app()
-
-Then start Galaxy with
-
-```
-uwsgi --yaml config/uwsgi.yaml --set galaxy_config_file=config/galaxy.yml
-```
-
-Galaxy will be available on the host under `http://localhost:8080/`.
+   Galaxy will now be accessible on port 8080.
 
 ---
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,13 +4,11 @@
 - hosts: localhost
   connection: local
   vars:
-    galaxy_uwsgi_yaml_parser: libyaml
     galaxy_config_style: yaml
     galaxy_layout: legacy-improved
     galaxy_server_dir: /galaxy/server
     galaxy_commit_id: release_20.01
     galaxy_repo: https://github.com/galaxyproject/galaxy.git
-    # galaxy_repo: https://github.com/CloudVE/galaxy.git
     galaxy_clone_depth: 1
     galaxy_virtualenv_command: /usr/bin/python3 -m virtualenv
     galaxy_virtualenv_python: python3
@@ -26,11 +24,14 @@
       uwsgi:
         virtualenv: "{{ galaxy_server_dir }}/.venv"
         pythonpath: "{{ galaxy_server_dir }}/lib"
-        module: galaxy.webapps.galaxy.buildapp:uwsgi_app()
+        mount: /=galaxy.webapps.galaxy.buildapp:uwsgi_app()
         http: 0.0.0.0:8080
+        manage-script-name: true
         static-map:
           - /static/style={{ galaxy_server_dir }}/static/style/blue
           - /static={{ galaxy_server_dir }}/static
+          - /favicon.ico=/galaxy/server/static/favicon.ico
+        static-safe: /galaxy/server/client/galaxy/images
         thunder-lock: true
         buffer-size: 16384
         offload-threads: 2
@@ -38,13 +39,10 @@
         threads: 4
         die-on-term: true
         master: true
-        hook-master-start:
-          - unix_signal:2 gracefully_kill_them_all
-          - unix_signal:15 gracefully_kill_them_all
+        hook-master-start: unix_signal:2 gracefully_kill_them_all
         enable-threads: true
         py-call-osafterfork: true
       galaxy:
-        database_connection: postgresql://galaxydbuser:42@gpsql/galaxy
         conda_auto_init: false
   roles:
     - galaxy

--- a/playbook.yml
+++ b/playbook.yml
@@ -7,7 +7,7 @@
     galaxy_config_style: yaml
     galaxy_layout: legacy-improved
     galaxy_server_dir: /galaxy/server
-    galaxy_commit_id: release_20.01
+    galaxy_commit_id: release_20.05
     galaxy_repo: https://github.com/galaxyproject/galaxy.git
     galaxy_clone_depth: 1
     galaxy_virtualenv_command: /usr/bin/python3 -m virtualenv


### PR DESCRIPTION
This PR makes the following changes:
1. Allows Galaxy container to be built and run without postgres dependency
2. Upgrades Galaxy to 20.05
3. Updates docs with instructions on how to run Galaxy standalone