### PR TITLE
use python3, not /usr/bin/python3

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -7,7 +7,7 @@
     galaxy_config_style: yaml
     galaxy_layout: legacy-improved
     galaxy_server_dir: /galaxy/server
-    galaxy_virtualenv_command: /usr/bin/python3 -m virtualenv
+    galaxy_virtualenv_command: python3 -m virtualenv
     galaxy_virtualenv_python: python3
     pip_extra_args: "--no-cache-dir --compile"
     galaxy_manage_database: false


### PR DESCRIPTION
python3 might be in /usr/local/bin/python3

I am currently working on porting galaxy k8s to use the more convenient python:3.7-slim image. This will allow easier transition to newer versions of python.