### PR TITLE
Move to ng pykube

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -4,7 +4,7 @@
 - hosts: localhost
   connection: local
   vars:
-    required_conditional_packages: ['psycopg2-binary', 'pykube', 'total-perspective-vortex']
+    required_conditional_packages: ['psycopg2-binary', 'ng-pykube', 'total-perspective-vortex']
   tasks:
   - name: Grep for required packages
     shell: "grep -w '{{ item }}' /galaxy/server/lib/galaxy/dependencies/conditional-requirements.txt"

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,7 +4,7 @@
 - hosts: localhost
   connection: local
   vars:
-    required_conditional_packages: ['psycopg2-binary', 'ng-pykube', 'total-perspective-vortex']
+    required_conditional_packages: ['psycopg2-binary', 'pykube-ng', 'total-perspective-vortex']
   tasks:
   - name: Grep for required packages
     shell: "grep -w '{{ item }}' /galaxy/server/lib/galaxy/dependencies/conditional-requirements.txt"


### PR DESCRIPTION
This PR moves the optional dependencies for the docker container to pykube-ng. It should be merged in sync probably with https://github.com/galaxyproject/galaxy/pull/15238 (or perhaps add some flexibility around that).