### PR TITLE
Add new-pykube as a required_conditional_package

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -4,7 +4,7 @@
 - hosts: localhost
   connection: local
   vars:
-    required_conditional_packages: ['psycopg2-binary', 'pykube-ng', 'total-perspective-vortex', 'sentry-sdk']
+    required_conditional_packages: ['psycopg2-binary', 'pykube-ng', 'new-pykube', 'total-perspective-vortex', 'sentry-sdk']
   tasks:
   - name: Grep for required packages
     shell: "grep -w '{{ item }}' /galaxy/server/lib/galaxy/dependencies/conditional-requirements.txt"


### PR DESCRIPTION
The [new-pykube](https://github.com/caas-team/new-pykube) project is a fork of the no longer maintained [pykube-ng](https://github.com/msabramo/pykube-ng) project, which is a fork of the archived [pykube](https://github.com/kelproject/pykube) project.  One more fork and we're doing it ourselves...

Listing both `pykube-ng` and `new-pykube` here shouldn't be a problem as long as only one is listed in the `conditional-requirements.txt` file. The `new-pykube` package contains updates to support the Gateway API.