### PR TITLE
Externalize the Galaxy container build into focused workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,195 @@
+# Lives in galaxyproject/galaxy-docker-k8s.
+# Reusable: check out galaxy@ref, build the image ONCE, smoke-test it on k3s, and
+# (optionally) publish the exact same image. No rebuilds — the built image is passed
+# between jobs as an artifact, which also fixes the cross-runner bug in PR #22763
+# (its smoke-test job ran `docker save` on a runner that never built the image).
+name: Build, test, publish Galaxy container (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      galaxy_ref:
+        description: 'Ref in galaxyproject/galaxy to build (branch, tag, or sha)'
+        required: true
+        type: string
+      image_tag:
+        description: 'Image tag to build/test/publish (e.g. dev, 24.1.1, 24.1-auto)'
+        required: true
+        type: string
+      publish:
+        description: 'Push to Docker Hub + Quay.io after the smoke test passes'
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      galaxy_version:
+        value: ${{ jobs.build.outputs.version }}
+      commit_sha:
+        value: ${{ jobs.build.outputs.commit_sha }}
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      commit_sha: ${{ steps.commit.outputs.sha_short }}
+    steps:
+      - name: Checkout Galaxy source
+        uses: actions/checkout@v6
+        with:
+          repository: galaxyproject/galaxy
+          ref: ${{ inputs.galaxy_ref }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Set commit info
+        id: commit
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Get Galaxy version
+        id: version
+        run: |
+          version=$(PYTHONPATH=lib python3 -c "from galaxy.version import VERSION; print(VERSION)")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build args
+        id: buildargs
+        run: |
+          echo "gitcommit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "builddate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image to a tarball (single build, real IMAGE_TAG baked in)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: .k8s_ci.Dockerfile
+          build-args: |
+            GIT_COMMIT=${{ steps.buildargs.outputs.gitcommit }}
+            BUILD_DATE=${{ steps.buildargs.outputs.builddate }}
+            IMAGE_TAG=${{ inputs.image_tag }}
+          tags: galaxy/galaxy-min:${{ inputs.image_tag }}
+          outputs: type=docker,dest=/tmp/galaxy-image.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: galaxy-image-${{ inputs.image_tag }}
+          path: /tmp/galaxy-image.tar
+          retention-days: 1
+
+  smoke-test:
+    name: Smoke test on k3s
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: galaxy-image-${{ inputs.image_tag }}
+          path: /tmp
+
+      - name: Start k8s locally
+        uses: jupyterhub/action-k3s-helm@v4
+        with:
+          k3s-version: v1.32.0+k3s1
+          metrics-enabled: false
+          traefik-enabled: false
+
+      - name: Import image into k3s
+        run: |
+          sudo k3s ctr images import /tmp/galaxy-image.tar
+          sudo k3s ctr images ls | grep galaxy
+
+      - name: Add Galaxy Helm repository
+        run: helm repo add galaxy https://github.com/CloudVE/helm-charts/raw/master
+
+      - name: Install Galaxy dependencies
+        run: |
+          helm install galaxy-deps galaxy/galaxy-deps \
+            --namespace galaxy-deps --create-namespace \
+            --set cvmfs.cvmfscsi.cache.alien.enabled=false \
+            --wait --timeout=1200s
+
+      - name: Install Galaxy using local image
+        run: |
+          helm install galaxy galaxy/galaxy \
+            --namespace galaxy --create-namespace \
+            --set persistence.accessMode="ReadWriteOnce" \
+            --set resources.requests.memory=0Mi,resources.requests.cpu=0m \
+            --set image.repository="galaxy/galaxy-min" \
+            --set image.tag="${{ inputs.image_tag }}" \
+            --set image.pullPolicy="Never" \
+            --wait --timeout=1200s
+
+      - name: Debug deployment on failure
+        if: failure()
+        run: |
+          echo "=== pods (galaxy) ===";       kubectl get pods -n galaxy -o wide
+          echo "=== pods (galaxy-deps) ===";  kubectl get pods -n galaxy-deps -o wide
+          echo "=== events (galaxy) ===";     kubectl get events -n galaxy --sort-by='.lastTimestamp' | tail -50
+          echo "=== events (galaxy-deps) ==="; kubectl get events -n galaxy-deps --sort-by='.lastTimestamp' | tail -50
+          for pod in $(kubectl get pods -n galaxy --field-selector=status.phase!=Running,status.phase!=Succeeded -o name 2>/dev/null); do
+            echo "--- $pod ---"; kubectl describe -n galaxy "$pod"
+          done
+
+      - name: Verify Galaxy API version
+        run: |
+          address=$(kubectl get svc -n galaxy galaxy-nginx -o jsonpath="http://{.spec.clusterIP}:{.spec.ports[0].port}/galaxy/api/version")
+          expected="${{ needs.build.outputs.version }}"
+          actual=$(curl -s "$address" | jq -r '"\(.version_major).\(.version_minor)"')
+          echo "expected=$expected actual=$actual"
+          [ "$expected" = "$actual" ] || { echo "::error::Version mismatch"; exit 1; }
+
+      - name: Verify client build is served
+        run: |
+          base=$(kubectl get svc -n galaxy galaxy-nginx -o jsonpath="http://{.spec.clusterIP}:{.spec.ports[0].port}")
+          code=$(curl -s -o /dev/null -w "%{http_code}" "${base}/galaxy/static/dist/base.css")
+          echo "status=$code"
+          [ "$code" = "200" ] || { echo "::error::client build not served"; exit 1; }
+
+  publish:
+    name: Publish image
+    runs-on: ubuntu-latest
+    needs: [build, smoke-test]
+    if: inputs.publish
+    steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: galaxy-image-${{ inputs.image_tag }}
+          path: /tmp
+
+      - name: Load image
+        run: docker load < /tmp/galaxy-image.tar
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Tag and push the tested image (no rebuild)
+        run: |
+          src="galaxy/galaxy-min:${{ inputs.image_tag }}"
+          for dest in \
+            "galaxy/galaxy-min:${{ inputs.image_tag }}" \
+            "quay.io/galaxyproject/galaxy-min:${{ inputs.image_tag }}"; do
+            docker tag "$src" "$dest"
+            docker push "$dest"
+          done

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,69 @@
+# Lives in galaxyproject/galaxy-docker-k8s.
+# Safety net: if a dispatch is ever missed (token expired, hook removed, fork), the
+# nightly cron still rebuilds :dev and any release_* branch that changed in the last
+# day. The build-test workflow's idempotent push makes a redundant run harmless.
+name: Nightly container reconcile
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: nightly-container
+  cancel-in-progress: true
+
+jobs:
+  detect-release-branches:
+    name: Find release_* branches changed in last 24h
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'galaxyproject'
+    outputs:
+      branches: ${{ steps.d.outputs.branches }}
+      has_branches: ${{ steps.d.outputs.has_branches }}
+    steps:
+      - name: Checkout Galaxy (full history)
+        uses: actions/checkout@v6
+        with:
+          repository: galaxyproject/galaxy
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect
+        id: d
+        run: |
+          since=$(date -d '24 hours ago' --iso-8601)
+          # Emit a JSON array of {branch, tag} objects, tag = "<X>-auto" (release_ stripped).
+          json="[]"
+          for b in $(git branch -r | sed 's# *origin/##' | grep '^release_'); do
+            if [ -n "$(git log --since="$since" --oneline "origin/$b" --max-count=1)" ]; then
+              json=$(echo "$json" | jq -c --arg b "$b" --arg t "${b#release_}-auto" '. + [{branch:$b, tag:$t}]')
+            fi
+          done
+          echo "branches=$json" >> "$GITHUB_OUTPUT"
+          [ "$json" = "[]" ] && echo "has_branches=false" >> "$GITHUB_OUTPUT" || echo "has_branches=true" >> "$GITHUB_OUTPUT"
+
+  dev:
+    name: Reconcile :dev
+    if: github.repository_owner == 'galaxyproject'
+    uses: ./.github/workflows/build-test.yml
+    with:
+      galaxy_ref: dev
+      image_tag: dev
+      publish: true
+    secrets: inherit
+
+  release-branches:
+    name: Reconcile ${{ matrix.branch }}
+    needs: detect-release-branches
+    if: needs.detect-release-branches.outputs.has_branches == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.detect-release-branches.outputs.branches) }}
+    uses: ./.github/workflows/build-test.yml
+    with:
+      galaxy_ref: ${{ matrix.branch }}
+      image_tag: ${{ matrix.tag }}
+      publish: true
+    secrets: inherit

--- a/.github/workflows/on-source-changed.yml
+++ b/.github/workflows/on-source-changed.yml
@@ -1,0 +1,150 @@
+# Lives in galaxyproject/galaxy-docker-k8s.
+# Entry point fired by the main repo's dispatch hook (and manually re-runnable).
+# Maps dev / release_branch / release -> image tag, skips already-published
+# releases, builds+tests+publishes, and opens the galaxy-helm bump PR on release.
+name: Build Galaxy container (on source change)
+
+on:
+  repository_dispatch:
+    types: [galaxy-source-changed]
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: 'dev | release_branch | release'
+        type: choice
+        options: [dev, release_branch, release]
+        required: true
+      ref:
+        description: 'galaxy ref to build (branch, tag, or sha)'
+        type: string
+        required: true
+      is_prerelease:
+        type: boolean
+        default: false
+
+concurrency:
+  group: build-${{ github.event.client_payload.ref || inputs.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resolve:
+    name: Resolve build parameters
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'galaxyproject'
+    outputs:
+      build_type: ${{ steps.r.outputs.build_type }}
+      ref: ${{ steps.r.outputs.ref }}
+      image_tag: ${{ steps.r.outputs.image_tag }}
+      is_prerelease: ${{ steps.r.outputs.is_prerelease }}
+      should_build: ${{ steps.skip.outputs.should_build }}
+    steps:
+      - name: Resolve dispatch vs manual inputs
+        id: r
+        run: |
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            build_type='${{ github.event.client_payload.build_type }}'
+            ref='${{ github.event.client_payload.ref }}'
+            is_prerelease='${{ github.event.client_payload.is_prerelease }}'
+          else
+            build_type='${{ inputs.build_type }}'
+            ref='${{ inputs.ref }}'
+            is_prerelease='${{ inputs.is_prerelease }}'
+          fi
+          case "$build_type" in
+            dev)            image_tag="dev" ;;
+            release_branch) image_tag="${ref#release_}-auto" ;;
+            release)        image_tag="${ref#v}" ;;
+            *) echo "::error::unknown build_type '$build_type'"; exit 1 ;;
+          esac
+          {
+            echo "build_type=$build_type"
+            echo "ref=$ref"
+            echo "image_tag=$image_tag"
+            echo "is_prerelease=$is_prerelease"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Skip releases already published
+        id: skip
+        run: |
+          should_build=true
+          if [[ "${{ steps.r.outputs.build_type }}" == "release" ]]; then
+            t="${{ steps.r.outputs.image_tag }}"
+            if docker manifest inspect "quay.io/galaxyproject/galaxy-min:$t" >/dev/null 2>&1 \
+               || docker manifest inspect "galaxy/galaxy-min:$t" >/dev/null 2>&1; then
+              echo "::notice::galaxy-min:$t already published — skipping duplicate build."
+              should_build=false
+            fi
+          fi
+          echo "should_build=$should_build" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build, test, publish
+    needs: resolve
+    if: needs.resolve.outputs.should_build == 'true'
+    uses: ./.github/workflows/build-test.yml
+    with:
+      galaxy_ref: ${{ needs.resolve.outputs.ref }}
+      image_tag: ${{ needs.resolve.outputs.image_tag }}
+      publish: true
+    secrets: inherit
+
+  helm-pr:
+    name: Open galaxy-helm bump PR
+    needs: [resolve, build]
+    if: needs.resolve.outputs.build_type == 'release' && needs.resolve.outputs.is_prerelease == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HELM_UPDATER_APP_ID }}
+          private-key: ${{ secrets.HELM_UPDATER_PKEY }}
+          repositories: galaxy-helm
+
+      - name: Checkout galaxy-helm
+        uses: actions/checkout@v6
+        with:
+          repository: galaxyproject/galaxy-helm
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Bump appVersion + image.tag
+        run: |
+          sed -i "s/^appVersion:.*/appVersion: \"${{ needs.build.outputs.galaxy_version }}\"/" galaxy/Chart.yaml
+          sed -i "s/^  tag:.*/  tag: \"${{ needs.resolve.outputs.image_tag }}\"/" galaxy/values.yaml
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.token.outputs.token }}
+          commit-message: "Update Galaxy to version ${{ needs.build.outputs.galaxy_version }}"
+          title: "Update Galaxy to version ${{ needs.build.outputs.galaxy_version }}"
+          body: |
+            Automated bump from the Galaxy container build.
+            - appVersion: `${{ needs.build.outputs.galaxy_version }}`
+            - image.tag: `${{ needs.resolve.outputs.image_tag }}`
+          branch: update-galaxy-${{ needs.build.outputs.galaxy_version }}
+          delete-branch: true
+          labels: |
+            patch
+            automated-update
+
+  notify-failure:
+    name: Notify on failure
+    needs: [resolve, build]
+    if: always() && needs.build.result == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          webhook: ${{ secrets.K8S_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: Galaxy container build failed (${{ needs.resolve.outputs.image_tag }})",
+              "blocks": [
+                { "type": "section", "text": { "type": "mrkdwn",
+                  "text": ":x: *Galaxy container build failed*\n*Tag:* `${{ needs.resolve.outputs.image_tag }}`\n*Ref:* `${{ needs.resolve.outputs.ref }}`\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" } }
+              ]
+            }

--- a/docs/container-build.md
+++ b/docs/container-build.md
@@ -1,0 +1,85 @@
+# Externalizing the Galaxy container build into `galaxy-docker-k8s`
+
+Moves ~1,700 lines of build/publish orchestration out of `galaxyproject/galaxy`'s
+CI and into `galaxyproject/galaxy-docker-k8s` (which already owns the ansible
+playbook the image is built from). The main repo keeps **one ~50-line file** whose
+only job is to say "source moved".
+
+## File layout
+
+```
+galaxyproject/galaxy
+  .github/workflows/notify-container-build.yml   # the only thing that stays in-repo
+
+galaxyproject/galaxy-docker-k8s
+  .k8s_ci.Dockerfile            # OPTIONAL: see "Where the Dockerfile lives" below
+  .github/workflows/
+    build-test.yml              # reusable: checkout galaxy@ref, build once, smoke-test, optionally publish
+    on-source-changed.yml       # entry point: fired by the dispatch hook (and manually)
+    nightly.yml                 # cron safety net: reconcile :dev + changed release_* branches
+```
+
+## Trigger model
+
+| Event in galaxy/galaxy | Hook sends `build_type` | Image tag | Publishes | Helm PR |
+|---|---|---|---|---|
+| push to `dev`          | `dev`            | `dev`         | ✅ | — |
+| push to `release_*`    | `release_branch` | `<X>-auto`    | ✅ | — |
+| release (published)    | `release`        | `<version>`   | ✅ | ✅ (non-prerelease) |
+| nightly cron           | — (cron)         | `dev` + `<X>-auto` | ✅ | — |
+
+`dev` is published on every green dev build here (simpler than the PR's
+"test-on-push, publish-nightly" split). If you prefer the old behaviour, set
+`publish: false` for the `dev` build_type in `on-source-changed.yml` and let
+`nightly.yml` be the only thing that publishes `:dev`.
+
+## Secrets to move to `galaxy-docker-k8s`
+
+Lift these from galaxy/galaxy → galaxy-docker-k8s repo secrets:
+
+- `QUAY_USERNAME`, `QUAY_PASSWORD`
+- `DOCKERHUB_USERNAME`, `DOCKERHUB_PASSWORD`
+- `K8S_SLACK_WEBHOOK_URL`
+- `HELM_UPDATER_APP_ID`, `HELM_UPDATER_PKEY`  (GitHub App with access to `galaxy-helm`)
+
+New secret in **galaxy/galaxy**:
+
+- `CONTAINER_BUILD_DISPATCH_TOKEN` — fine-grained PAT **or** GitHub App token with
+  `Contents: read` on `galaxyproject/galaxy-docker-k8s`. The built-in
+  `GITHUB_TOKEN` **cannot** dispatch across repos.
+
+## Where the Dockerfile lives
+
+`.k8s_ci.Dockerfile` is the one artifact coupled to the Galaxy source layout (it
+`rm -rf`s specific paths, stages the client build, etc.). Two options:
+
+1. **Keep it in galaxy/galaxy (recommended).** `build-test.yml` checks out
+   galaxy@ref and builds with that checkout's Dockerfile, so layout changes stay
+   atomic with the code that caused them. This is what the drafts assume.
+2. Move it to galaxy-docker-k8s. Lower main-repo footprint, but a source-layout
+   change in galaxy can now break the build out-of-band. The nightly dev build
+   catches such drift within a day, but option 1 is safer.
+
+## Migration order
+
+1. Create the secrets above in both repos.
+2. Land the three workflows in `galaxy-docker-k8s`. Test with **workflow_dispatch**
+   (`on-source-changed.yml` → build_type=dev, ref=dev) before wiring the hook.
+3. Land `notify-container-build.yml` in galaxy/galaxy.
+4. **Delete** `build_container_image.yaml` (and PR #22763's four new files) from
+   galaxy/galaxy. The "off switch" is now `git rm`, not a manual GitHub-UI toggle.
+5. Update the helm/quay/dockerhub README pointers to note the build now lives in
+   galaxy-docker-k8s.
+
+## What this fixes vs PR #22763
+
+- **One build instead of two/three.** The image is built once and passed between
+  jobs as an artifact; smoke-test and publish reuse the exact bytes that were tested.
+- **Fixes a latent bug.** PR #22763's `container_build_test.yml` smoke-test job runs
+  `docker save galaxy/galaxy-min:<tag>` on a runner that never built the image
+  (build + smoke are separate runners with separate Docker daemons) — that `save`
+  has nothing to save. Artifact passing makes the tested image actually present.
+- **`IMAGE_TAG` baked correctly.** Built once with the real tag, so the
+  `/api/version` `image_tag` and the OCI `version` label match what's published
+  (the PR builds the smoke image with a throwaway `test` tag).
+- **No manual disable step.** Removing the build is a deletion in git history.

--- a/docs/galaxy-repo--notify-container-build.yml
+++ b/docs/galaxy-repo--notify-container-build.yml
@@ -1,0 +1,52 @@
+# Lives in galaxyproject/galaxy — the ONLY container-build file that stays in the
+# main repo. It builds nothing; it just tells galaxy-docker-k8s that source moved.
+#
+# Requires an org/repo secret CONTAINER_BUILD_DISPATCH_TOKEN: a fine-grained PAT or
+# GitHub App token with "Contents: read" on galaxyproject/galaxy-docker-k8s.
+# (The built-in GITHUB_TOKEN cannot dispatch to another repository.)
+name: Notify container build repo
+
+on:
+  push:
+    branches:
+      - dev
+      - release_*
+  release:
+    types: [released, prereleased]
+
+jobs:
+  dispatch:
+    name: Dispatch build to galaxy-docker-k8s
+    if: github.repository == 'galaxyproject/galaxy'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute payload
+        id: p
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "build_type=release"                              >> "$GITHUB_OUTPUT"
+            echo "ref=${{ github.event.release.tag_name }}"        >> "$GITHUB_OUTPUT"
+            echo "is_prerelease=${{ github.event.release.prerelease }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.ref }}" == "refs/heads/dev" ]]; then
+            echo "build_type=dev"   >> "$GITHUB_OUTPUT"
+            echo "ref=dev"          >> "$GITHUB_OUTPUT"
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "build_type=release_branch"           >> "$GITHUB_OUTPUT"
+            echo "ref=${GITHUB_REF#refs/heads/}"        >> "$GITHUB_OUTPUT"
+            echo "is_prerelease=false"                  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger galaxy-docker-k8s
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CONTAINER_BUILD_DISPATCH_TOKEN }}
+          repository: galaxyproject/galaxy-docker-k8s
+          event-type: galaxy-source-changed
+          client-payload: |
+            {
+              "build_type": "${{ steps.p.outputs.build_type }}",
+              "ref": "${{ steps.p.outputs.ref }}",
+              "sha": "${{ github.sha }}",
+              "is_prerelease": "${{ steps.p.outputs.is_prerelease }}"
+            }


### PR DESCRIPTION
## What

Moves the Galaxy container build/test/publish orchestration **out of `galaxyproject/galaxy` CI** and into this repo, which already owns the ansible playbook the image is built from. The main repo keeps a single ~50-line dispatch hook (reference copy at `docs/galaxy-repo--notify-container-build.yml`).

Context / motivation: galaxyproject/galaxy#22763 grew the in-repo container CI to ~1,700 lines across 5 workflows. This is the alternative — keep the deployment/orchestration here (fast iteration, no forward/backport ceremony, `@ksuderman` as maintainer) and leave only `.k8s_ci.Dockerfile` + a tiny hook in the main repo.

**Draft** — not for merge yet. Posting so there's something concrete to discuss on #22763. Secrets/token wiring still needs to be set up before any of this runs (see `docs/container-build.md`).

## Files

| File | Role |
|---|---|
| `.github/workflows/build-test.yml` | Reusable: checkout `galaxy@ref` → build image **once** → smoke-test on k3s → optionally publish the exact tested image (passed between jobs as an artifact) |
| `.github/workflows/on-source-changed.yml` | Entry point fired by the main-repo dispatch hook (+ manual). Maps `dev`/`release_branch`/`release` → tag, skips already-published releases, opens the `galaxy-helm` bump PR on release |
| `.github/workflows/nightly.yml` | Cron safety net: reconcile `:dev` and changed `release_*` branches if a dispatch is missed |
| `docs/container-build.md` | Secrets table, migration order, design notes |
| `docs/galaxy-repo--notify-container-build.yml` | Reference copy of the hook to drop into `galaxyproject/galaxy` (does **not** run from `docs/`) |

## Trigger model

| Event in galaxy/galaxy | `build_type` | Image tag | Publishes | Helm PR |
|---|---|---|---|---|
| push to `dev` | `dev` | `dev` | ✅ | — |
| push to `release_*` | `release_branch` | `<X>-auto` | ✅ | — |
| release (published) | `release` | `<version>` | ✅ | ✅ (non-prerelease) |
| nightly cron | — | `dev` + `<X>-auto` | ✅ | — |

Near-realtime via `repository_dispatch`, with the nightly cron as a safety net (idempotent: releases skip via `docker manifest inspect`).

## Improvements vs the in-repo PR

- **Single build.** Image built once, passed downstream as an artifact; smoke-test and publish reuse the exact tested bytes (the in-repo PR builds 2–3×).
- **Fixes a latent bug.** In #22763 the smoke-test job runs `docker save galaxy/galaxy-min:<tag>` on a runner that never built the image (build + smoke are separate runners → separate Docker daemons), so there's nothing to save. Artifact passing makes the tested image actually present.
- **`IMAGE_TAG` baked correctly** (lands in `/api/version` + the OCI `version` label) — built once with the real tag instead of a throwaway `test` tag.
- **No manual disable step** — the main-repo "off switch" becomes `git rm`, not a GitHub-UI toggle.

## Before this can run (see `docs/container-build.md`)

- Move secrets here: `QUAY_*`, `DOCKERHUB_*`, `K8S_SLACK_WEBHOOK_URL`, `HELM_UPDATER_APP_ID`/`HELM_UPDATER_PKEY`.
- Add `CONTAINER_BUILD_DISPATCH_TOKEN` in `galaxyproject/galaxy` (fine-grained PAT / App token with `Contents: read` here — `GITHUB_TOKEN` can't dispatch cross-repo).
- Decide where `.k8s_ci.Dockerfile` lives (these workflows assume it stays in galaxy/galaxy and is built from the `galaxy@ref` checkout).

🤖 Drafted with Claude Code.
